### PR TITLE
Dev

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,7 +31,3 @@ DISCORD_WEBHOOK_URL=""
 RATE_LIMIT_TTL="60"
 RATE_LIMIT_MAX="100"
 
-# Docker Swarm / NFS Configuration (for global deployment)
-NFS_SERVER="10.0.0.1"
-NFS_PATH="/mnt/lyttlenginx/letsencrypt"
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,14 +7,17 @@ WORKDIR /app
 COPY package*.json ./
 COPY prisma ./prisma/
 
-# Install dependencies and generate Prisma client
-RUN npm ci --only=production && \
-    npm cache clean --force && \
+# Install ALL dependencies (including devDependencies needed for build)
+RUN npm ci && \
     npx prisma generate
 
 # Copy source and build
 COPY . .
 RUN npm run build
+
+# Prune dev dependencies after build
+RUN npm prune --production && \
+    npm cache clean --force
 
 # Production stage
 FROM debian:bookworm-slim

--- a/deploy-swarm.sh
+++ b/deploy-swarm.sh
@@ -69,25 +69,9 @@ else
     echo -e "${YELLOW}⚠ psql not found, skipping database check${NC}"
 fi
 
-# Check if using NFS
 echo ""
-if [ -n "$NFS_SERVER" ] && [ -n "$NFS_PATH" ]; then
-    echo -e "${BLUE}NFS Configuration:${NC}"
-    echo "  Server: $NFS_SERVER"
-    echo "  Path: $NFS_PATH"
-
-    # Test NFS connectivity
-    if command -v showmount > /dev/null 2>&1; then
-        if showmount -e "$NFS_SERVER" > /dev/null 2>&1; then
-            echo -e "${GREEN}✓ NFS server is accessible${NC}"
-        else
-            echo -e "${YELLOW}⚠ Cannot connect to NFS server${NC}"
-        fi
-    fi
-else
-    echo -e "${YELLOW}⚠ NFS not configured - using local volumes${NC}"
-    echo "  This is OK for testing but NOT recommended for production"
-fi
+echo -e "${GREEN}✓ Certificate storage: Database-driven (no shared storage needed)${NC}"
+echo "  Certificates are stored in PostgreSQL and synced to local filesystem on each node"
 
 # Deploy stack
 echo ""

--- a/docker-compose.swarm.yml
+++ b/docker-compose.swarm.yml
@@ -79,15 +79,6 @@ services:
     # This ensures all nodes can bind to ports 80/443
     network_mode: host
 
-    # Volumes for persistence
-    volumes:
-      # Let's Encrypt certificates - shared across cluster
-      - letsencrypt-data:/etc/letsencrypt:rw
-      # NGINX logs (local to each node)
-      - nginx-logs:/var/log/nginx:rw
-      # Application logs (local to each node)
-      - app-logs:/app/logs:rw
-
     # Health check
     healthcheck:
       test: [ "/healthcheck.sh" ]
@@ -103,28 +94,3 @@ services:
         max-size: "10m"
         max-file: "3"
         labels: "app,version"
-
-# Volumes
-volumes:
-  # Shared volume for Let's Encrypt certificates
-  # IMPORTANT: Use a distributed storage driver in production (e.g., NFS, GlusterFS, Ceph)
-  letsencrypt-data:
-    driver: local
-    driver_opts:
-      type: nfs
-      o: addr=${NFS_SERVER:-10.0.0.1},rw,nolock,soft
-      device: ":${NFS_PATH:-/mnt/lyttlenginx/letsencrypt}"
-
-  # Local volumes for logs (per-node)
-  nginx-logs:
-    driver: local
-
-  app-logs:
-    driver: local
-
-# Networks (not used when network_mode: host)
-# networks:
-#   lyttlenginx-network:
-#     driver: overlay
-#     attachable: true
-


### PR DESCRIPTION
This pull request removes support for NFS-based shared storage for Let's Encrypt certificates, transitioning the deployment to use database-driven certificate storage instead. The changes simplify the deployment configuration and Docker setup, as shared volumes and related environment variables are no longer required.

**Deployment and Storage Configuration:**

* Removed NFS server and path configuration from `.env.example`, reflecting the move away from NFS for certificate storage.
* Updated `deploy-swarm.sh` to eliminate NFS checks and instead indicate that certificate storage is now handled via the database and synced locally on each node.
* Removed the shared `letsencrypt-data` NFS volume and local log volumes from `docker-compose.swarm.yml`, as well as the associated volume definitions. [[1]](diffhunk://#diff-a80a5bbed89616cec7080649fdeebab6538adb1409777c82c50a6a9c6ec9bc9bL82-L90) [[2]](diffhunk://#diff-a80a5bbed89616cec7080649fdeebab6538adb1409777c82c50a6a9c6ec9bc9bL106-L130)

**Docker Build Process:**

* Modified the `Dockerfile` to install all dependencies (including devDependencies) for the build phase, then prune devDependencies and clean the npm cache after building, optimizing the final production image.